### PR TITLE
Fixed word selection with double click in the highlighter mode

### DIFF
--- a/Source/SynEditHighlighter.pas
+++ b/Source/SynEditHighlighter.pas
@@ -1119,12 +1119,7 @@ end;
 
 function TSynCustomHighlighter.IsIdentChar(AChar: WideChar): Boolean;
 begin
-  case AChar of
-    '_', '0'..'9', 'A'..'Z', 'a'..'z':
-      Result := True;
-    else
-      Result := False;
-  end;
+  Result := AChar >= #33;
 end;
 
 function TSynCustomHighlighter.IsKeyword(const AKeyword: UnicodeString): Boolean;


### PR DESCRIPTION
 It started to work with all chars in the highlighter mode (not with only latin chars as it was before).