### PR TITLE
Proposal Form Height Growth

### DIFF
--- a/Source/SynCompletionProposal.pas
+++ b/Source/SynCompletionProposal.pas
@@ -1577,6 +1577,7 @@ function TSynBaseCompletionProposalForm.CanResize(var NewWidth, NewHeight: Integ
 var
   NewLinesInWindow: Integer;
   BorderWidth: Integer;
+  tmpHeight : integer;
 begin
   Result := True;
   case FDisplayKind of
@@ -1586,10 +1587,13 @@ begin
 
       if FEffectiveItemHeight <> 0 then
       begin
-        NewLinesInWindow := (NewHeight-FHeightBuffer) div FEffectiveItemHeight;
+        tmpHeight := NewHeight - BorderWidth;
+        NewLinesInWindow := (tmpHeight - FHeightBuffer) div FEffectiveItemHeight;
+
         if NewLinesInWindow < 1 then
           NewLinesInWindow := 1;
-      end else
+      end
+      else
         NewLinesInWindow := 0;
 
       FLinesInWindow := NewLinesInWindow;


### PR DESCRIPTION
Corrected proposal form height growth. On resizing the proposal form, can resize would re-calc the number of lines shown. The issue with this is that the height of the boarder was not being removed before calculation. This would mean the height would be increased if the boarder width could accommodate another  item. The growth would appear in the next show, and cause another resize. This would repeat.