### PR TITLE
Wrong path to SynEditReg.dcr in design packages for Delphi 2010 and up

### DIFF
--- a/Packages/2010/SynEdit_D.dpk
+++ b/Packages/2010/SynEdit_D.dpk
@@ -1,6 +1,6 @@
 package SynEdit_D;
 
-{$R '..\Source\SynEditReg.dcr'}
+{$R '..\..\Source\SynEditReg.dcr'}
 {$IFDEF IMPLICITBUILDING This IFDEF should not be used by users}
 {$ALIGN 8}
 {$ASSERTIONS ON}

--- a/Packages/2010/SynEdit_D.dproj
+++ b/Packages/2010/SynEdit_D.dproj
@@ -88,7 +88,7 @@
 			<DelphiCompile Include="$(MainSource)">
 				<MainSource>MainSource</MainSource>
 			</DelphiCompile>
-			<DCCReference Include="..\Source\SynEditReg.dcr"/>
+			<DCCReference Include="..\..\Source\SynEditReg.dcr"/>
 			<DCCReference Include="designide.dcp"/>
 			<DCCReference Include="SynEdit_R.dcp"/>
 			<DCCReference Include="..\..\Source\SynEditReg.pas"/>

--- a/Packages/XE/SynEdit_D.dpk
+++ b/Packages/XE/SynEdit_D.dpk
@@ -1,6 +1,6 @@
 package SynEdit_D;
 
-{$R '..\Source\SynEditReg.dcr'}
+{$R '..\..\Source\SynEditReg.dcr'}
 {$IFDEF IMPLICITBUILDING This IFDEF should not be used by users}
 {$ALIGN 8}
 {$ASSERTIONS ON}

--- a/Packages/XE/SynEdit_D.dproj
+++ b/Packages/XE/SynEdit_D.dproj
@@ -88,7 +88,7 @@
 			<DelphiCompile Include="$(MainSource)">
 				<MainSource>MainSource</MainSource>
 			</DelphiCompile>
-			<DCCReference Include="..\Source\SynEditReg.dcr"/>
+			<DCCReference Include="..\..\Source\SynEditReg.dcr"/>
 			<DCCReference Include="designide.dcp"/>
 			<DCCReference Include="SynEdit_R.dcp"/>
 			<DCCReference Include="..\..\Source\SynEditReg.pas"/>

--- a/Packages/XE2/SynEdit_D.dpk
+++ b/Packages/XE2/SynEdit_D.dpk
@@ -1,6 +1,6 @@
 package SynEdit_D;
 
-{$R '..\Source\SynEditReg.dcr'}
+{$R '..\..\Source\SynEditReg.dcr'}
 {$IFDEF IMPLICITBUILDING This IFDEF should not be used by users}
 {$ALIGN 8}
 {$ASSERTIONS ON}

--- a/Packages/XE2/SynEdit_D.dproj
+++ b/Packages/XE2/SynEdit_D.dproj
@@ -88,7 +88,7 @@
 			<DelphiCompile Include="$(MainSource)">
 				<MainSource>MainSource</MainSource>
 			</DelphiCompile>
-			<DCCReference Include="..\Source\SynEditReg.dcr"/>
+			<DCCReference Include="..\..\Source\SynEditReg.dcr"/>
 			<DCCReference Include="designide.dcp"/>
 			<DCCReference Include="SynEdit_R.dcp"/>
 			<DCCReference Include="..\..\Source\SynEditReg.pas"/>

--- a/Packages/XE3/SynEdit_D.dpk
+++ b/Packages/XE3/SynEdit_D.dpk
@@ -1,6 +1,6 @@
 package SynEdit_D;
 
-{$R '..\Source\SynEditReg.dcr'}
+{$R '..\..\Source\SynEditReg.dcr'}
 {$IFDEF IMPLICITBUILDING This IFDEF should not be used by users}
 {$ALIGN 8}
 {$ASSERTIONS ON}

--- a/Packages/XE3/SynEdit_D.dproj
+++ b/Packages/XE3/SynEdit_D.dproj
@@ -88,7 +88,7 @@
 			<DelphiCompile Include="$(MainSource)">
 				<MainSource>MainSource</MainSource>
 			</DelphiCompile>
-			<DCCReference Include="..\Source\SynEditReg.dcr"/>
+			<DCCReference Include="..\..\Source\SynEditReg.dcr"/>
 			<DCCReference Include="designide.dcp"/>
 			<DCCReference Include="SynEdit_R.dcp"/>
 			<DCCReference Include="..\..\Source\SynEditReg.pas"/>

--- a/Packages/XE4/SynEdit_D.dpk
+++ b/Packages/XE4/SynEdit_D.dpk
@@ -1,6 +1,6 @@
 package SynEdit_D;
 
-{$R '..\Source\SynEditReg.dcr'}
+{$R '..\..\Source\SynEditReg.dcr'}
 {$IFDEF IMPLICITBUILDING This IFDEF should not be used by users}
 {$ALIGN 8}
 {$ASSERTIONS ON}

--- a/Packages/XE4/SynEdit_D.dproj
+++ b/Packages/XE4/SynEdit_D.dproj
@@ -88,7 +88,7 @@
 			<DelphiCompile Include="$(MainSource)">
 				<MainSource>MainSource</MainSource>
 			</DelphiCompile>
-			<DCCReference Include="..\Source\SynEditReg.dcr"/>
+			<DCCReference Include="..\..\Source\SynEditReg.dcr"/>
 			<DCCReference Include="designide.dcp"/>
 			<DCCReference Include="SynEdit_R.dcp"/>
 			<DCCReference Include="..\..\Source\SynEditReg.pas"/>

--- a/Packages/XE5/SynEdit_D.dpk
+++ b/Packages/XE5/SynEdit_D.dpk
@@ -1,6 +1,6 @@
 package SynEdit_D;
 
-{$R '..\Source\SynEditReg.dcr'}
+{$R '..\..\Source\SynEditReg.dcr'}
 {$IFDEF IMPLICITBUILDING This IFDEF should not be used by users}
 {$ALIGN 8}
 {$ASSERTIONS ON}

--- a/Packages/XE5/SynEdit_D.dproj
+++ b/Packages/XE5/SynEdit_D.dproj
@@ -88,7 +88,7 @@
 			<DelphiCompile Include="$(MainSource)">
 				<MainSource>MainSource</MainSource>
 			</DelphiCompile>
-			<DCCReference Include="..\Source\SynEditReg.dcr"/>
+			<DCCReference Include="..\..\Source\SynEditReg.dcr"/>
 			<DCCReference Include="designide.dcp"/>
 			<DCCReference Include="SynEdit_R.dcp"/>
 			<DCCReference Include="..\..\Source\SynEditReg.pas"/>

--- a/Packages/XE6/SynEdit_D.dpk
+++ b/Packages/XE6/SynEdit_D.dpk
@@ -1,6 +1,6 @@
 package SynEdit_D;
 
-{$R '..\Source\SynEditReg.dcr'}
+{$R '..\..\Source\SynEditReg.dcr'}
 {$IFDEF IMPLICITBUILDING This IFDEF should not be used by users}
 {$ALIGN 8}
 {$ASSERTIONS ON}

--- a/Packages/XE6/SynEdit_D.dproj
+++ b/Packages/XE6/SynEdit_D.dproj
@@ -88,7 +88,7 @@
 			<DelphiCompile Include="$(MainSource)">
 				<MainSource>MainSource</MainSource>
 			</DelphiCompile>
-			<DCCReference Include="..\Source\SynEditReg.dcr"/>
+			<DCCReference Include="..\..\Source\SynEditReg.dcr"/>
 			<DCCReference Include="designide.dcp"/>
 			<DCCReference Include="SynEdit_R.dcp"/>
 			<DCCReference Include="..\..\Source\SynEditReg.pas"/>

--- a/Packages/XE7/SynEdit_D.dpk
+++ b/Packages/XE7/SynEdit_D.dpk
@@ -1,6 +1,6 @@
 package SynEdit_D;
 
-{$R '..\Source\SynEditReg.dcr'}
+{$R '..\..\Source\SynEditReg.dcr'}
 {$IFDEF IMPLICITBUILDING This IFDEF should not be used by users}
 {$ALIGN 8}
 {$ASSERTIONS ON}

--- a/Packages/XE7/SynEdit_D.dproj
+++ b/Packages/XE7/SynEdit_D.dproj
@@ -88,7 +88,7 @@
         <DelphiCompile Include="$(MainSource)">
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
-        <DCCReference Include="..\Source\SynEditReg.dcr"/>
+        <DCCReference Include="..\..\Source\SynEditReg.dcr"/>
         <DCCReference Include="designide.dcp"/>
         <DCCReference Include="SynEdit_R.dcp"/>
         <DCCReference Include="..\..\Source\SynEditReg.pas"/>

--- a/Packages/XE8/SynEdit_D.dproj
+++ b/Packages/XE8/SynEdit_D.dproj
@@ -88,7 +88,7 @@
 			<DelphiCompile Include="$(MainSource)">
 				<MainSource>MainSource</MainSource>
 			</DelphiCompile>
-			<DCCReference Include="..\Source\SynEditReg.dcr"/>
+			<DCCReference Include="..\..\Source\SynEditReg.dcr"/>
 			<DCCReference Include="designide.dcp"/>
 			<DCCReference Include="SynEdit_R.dcp"/>
 			<DCCReference Include="..\..\Source\SynEditReg.pas"/>


### PR DESCRIPTION
This also fixes issue #21