### PR TITLE
Add customization options for drawing modified line markers

### DIFF
--- a/Source/SynEdit.pas
+++ b/Source/SynEdit.pas
@@ -2656,8 +2656,8 @@ procedure TCustomSynEdit.PaintGutter(const AClip: TRect;
   procedure DrawModification(Color: TColor; Top, Bottom: Integer);
   begin
     Canvas.Pen.Color := Color;
-    Canvas.MoveTo(fGutterWidth - FGutter.RightOffset - 2, Top);
-    Canvas.LineTo(fGutterWidth - FGutter.RightOffset - 2, Bottom);
+    Canvas.MoveTo(fGutterWidth - fGutter.RightOffset - fGutter.ModificationBarWidth, Top);
+    Canvas.LineTo(fGutterWidth - fGutter.RightOffset - fGutter.ModificationBarWidth, Bottom);
   end;
 
 var
@@ -2775,9 +2775,9 @@ begin
         if FGutter.ShowModification then
           case TSynEditStringList(FLines).Modification[cLine - 1] of
             smModified:
-              DrawModification(clYellow, rcLine.Top, rcLine.Bottom);
+              DrawModification(fGutter.ModificationColorModified, rcLine.Top, rcLine.Bottom);
             smSaved:
-              DrawModification(clLime, rcLine.Top, rcLine.Bottom);
+              DrawModification(fGutter.ModificationColorSaved, rcLine.Top, rcLine.Bottom);
           end;
       end;
       // now erase the remaining area if any
@@ -2805,9 +2805,9 @@ begin
         vLineTop := (LineToRow(cLine) - TopLine) * FTextHeight;
         case TSynEditStringList(FLines).Modification[cLine - 1] of
           smModified:
-            DrawModification(clYellow, vLineTop, vLineTop + FTextHeight);
+            DrawModification(fGutter.ModificationColorModified, vLineTop, vLineTop + fTextHeight);
           smSaved:
-            DrawModification(clLime, vLineTop, vLineTop + FTextHeight);
+            DrawModification(fGutter.ModificationColorSaved, vLineTop, vLineTop + fTextHeight);
         end;
       end;
   end;
@@ -8288,6 +8288,8 @@ end;
 procedure TCustomSynEdit.MarkModifiedLinesAsSaved;
 begin
   TSynEditStringList(FLines).MarkModifiedLinesAsSaved;
+  if fGutter.ShowModification then
+    InvalidateGutter;
 end;
 
 function TCustomSynEdit.GetSelStart: Integer;
@@ -11028,6 +11030,8 @@ end;
 procedure TCustomSynEdit.ResetModificationIndicator;
 begin
   TSynEditStringList(FLines).ResetModificationIndicator;
+  if fGutter.ShowModification then
+    InvalidateGutter;
 end;
 
 procedure TCustomSynEdit.AddMouseCursorHandler(aHandler: TMouseCursorEvent);

--- a/Source/SynEditMiscClasses.pas
+++ b/Source/SynEditMiscClasses.pas
@@ -125,6 +125,9 @@ type
     fGradientStartColor: TColor;
     fGradientEndColor: TColor;
     fGradientSteps: Integer;
+    fModificationBarWidth: Integer;
+    fModificationColorModified: TColor;
+    fModificationColorSaved: TColor;
     procedure SetAutoSize(const Value: boolean);
     procedure SetBorderColor(const Value: TColor);
     procedure SetColor(const Value: TColor);
@@ -147,6 +150,9 @@ type
     procedure SetGradientEndColor(const Value: TColor);
     procedure SetGradientSteps(const Value: Integer);
     function GetWidth: integer;
+    procedure SetModificationColorModified(const Value: TColor);
+    procedure SetModificationColorSaved(const Value: TColor);
+    procedure SetModificationBarWidth(const Value: Integer);
   public
     constructor Create;
     destructor Destroy; override;
@@ -168,6 +174,12 @@ type
       default FALSE;
     property LeftOffset: integer read fLeftOffset write SetLeftOffset
       default 16;
+    property ModificationBarWidth: Integer read fModificationBarWidth
+      write SetModificationBarWidth default 2;
+    property ModificationColorModified: TColor read fModificationColorModified
+      write SetModificationColorModified default clYellow;
+    property ModificationColorSaved: TColor read fModificationColorSaved
+      write SetModificationColorSaved default clLime;
     property RightOffset: integer read fRightOffset write SetRightOffset
       default 2;
     property ShowLineNumbers: boolean read fShowLineNumbers
@@ -468,6 +480,11 @@ begin
   fGradientStartColor := clWindow;
   fGradientEndColor := clBtnFace;
   fGradientSteps := 48;
+
+  fShowModification := FALSE;
+  fModificationBarWidth := 2;
+  fModificationColorModified := clYellow;
+  fModificationColorSaved := clLime;
 end;
 
 destructor TSynGutter.Destroy;
@@ -694,9 +711,36 @@ begin
   end;
 end;
 
+procedure TSynGutter.SetModificationBarWidth(const Value: Integer);
+begin
+  if fModificationBarWidth <> Value then
+  begin
+    fModificationBarWidth := Value;
+    if Assigned(fOnChange) then fOnChange(Self);
+  end;
+end;
+
+procedure TSynGutter.SetModificationColorModified(const Value: TColor);
+begin
+  if fModificationColorModified <> Value then
+  begin
+    fModificationColorModified := Value;
+    if Assigned(fOnChange) then fOnChange(Self);
+  end;
+end;
+
+procedure TSynGutter.SetModificationColorSaved(const Value: TColor);
+begin
+  if fModificationColorSaved <> Value then
+  begin
+    fModificationColorSaved := Value;
+    if Assigned(fOnChange) then fOnChange(Self);
+  end;
+end;
+
 procedure TSynGutter.SetBorderColor(const Value: TColor);
 begin
-  if fBorderColor <> Value then 
+  if fBorderColor <> Value then
   begin
     fBorderColor := Value;
     if Assigned(fOnChange) then fOnChange(Self);


### PR DESCRIPTION
A small update for the new feature to highlight modified lines: customize the colors used and the width of the bar being drawn in the gutter.