### PR TITLE
Changes to compile in D6.

### DIFF
--- a/Source/SynEdit.pas
+++ b/Source/SynEdit.pas
@@ -96,6 +96,10 @@ const
    // not defined in all Delphi versions
   WM_MOUSEWHEEL = $020A;
 {$ENDIF}
+{$IFNDEF SYN_COMPILER_7_UP}
+  // not defined in all Delphi versions
+  WS_EX_COMPOSITED = $02000000;
+{$ENDIF}
 
    // maximum scroll range
   MAX_SCROLL = 32767;


### PR DESCRIPTION
Removed BOM from SynEdit.pas.
Work around missing TBitmap.SetSize in D6.