### PR TITLE
Issue #87: LineModifications: marked as saved is never reset to Modified

### DIFF
--- a/Source/SynEditTextBuffer.pas
+++ b/Source/SynEditTextBuffer.pas
@@ -920,6 +920,7 @@ begin
       Exclude(FFlags, sfHasTabs);
       Exclude(FFlags, sfHasNoTabs);
       Include(FFlags, sfModified);
+      Exclude(FFlags, sfSaved);
       {$IFDEF OWN_UnicodeString_MEMMGR}
         SetListString(Index, S);
       {$ELSE}


### PR DESCRIPTION
…aves the file and then modifies it again. Visually the line was still marked as saved instead of modified.