### PR TITLE
SQL: Detect successive backslashes. Fixes issue #53.

### DIFF
--- a/Source/SynHighlighterSQL.pas
+++ b/Source/SynHighlighterSQL.pas
@@ -1448,6 +1448,8 @@ begin
 end;
 
 procedure TSynSQLSyn.AsciiCharProc;
+var
+  IsEsc: Boolean;
 begin
   // Oracle SQL allows strings to go over multiple lines
   if FLine[Run] = #0 then
@@ -1472,12 +1474,17 @@ begin
     end
     else
     begin
+      IsEsc := False;
       if (Run > 0) or (FRange <> rsString) or
         ((FLine[Run] <> #39) and (FLine[Run - 1] <> '\')) then
       begin
         FRange := rsString;
         repeat
-          if (FLine[Run] <> '\') and (FLine[Run + 1] = #39) then
+          if FLine[Run] = '\' then
+            IsEsc := not IsEsc
+          else
+            IsEsc := False;
+          if (not IsEsc) and (FLine[Run + 1] = #39) then
           begin
             Inc(Run);
             Break;
@@ -1485,7 +1492,7 @@ begin
           Inc(Run);
         until IsLineEnd(Run);
       end;
-      if (FLine[Run] = #39) and not(FLine[Run-1] = '\') then
+      if (FLine[Run] = #39) and (not IsEsc) then
       begin
         Inc(Run);
         FRange := rsUnknown;


### PR DESCRIPTION
Detect as escape chars so '\\' does not display text right besides that as string.

Copied fix from here: https://github.com/HeidiSQL/HeidiSQL/commit/2436cdf388bfcf71310b97cc503d303730fd0b06