### PR TITLE
#127: Keys for the delphi IDE are stored in the 32 bit section of reg…

### DIFF
--- a/Source/SynHighlighterPas.pas
+++ b/Source/SynHighlighterPas.pas
@@ -1373,13 +1373,21 @@ procedure TSynPasSyn.EnumUserSettings(DelphiVersions: TStrings);
     end;
   end;
 
+var
+  LWowNode : string;
 begin
   { returns the user settings that exist in the registry }
   // See UseUserSettings below where these strings are used
-  LoadKeyVersions('\SOFTWARE\Borland\Delphi', '');
-  LoadKeyVersions('\SOFTWARE\Borland\BDS', BDSVersionPrefix);
-  LoadKeyVersions('\SOFTWARE\CodeGear\BDS', BDSVersionPrefix);
-  LoadKeyVersions('\SOFTWARE\Embarcadero\BDS', BDSVersionPrefix);
+  LWowNode := '';
+  {$ifdef WIN64}
+    LWowNode := 'WOW6432Node\';
+  {$ENDIF}
+
+  LoadKeyVersions('\SOFTWARE\'+ LWOWNode + 'Borland\Delphi', '');
+  LoadKeyVersions('\SOFTWARE\'+ LWOWNode + 'Borland\BDS', BDSVersionPrefix);
+  LoadKeyVersions('\SOFTWARE\'+ LWOWNode + 'CodeGear\BDS', BDSVersionPrefix);
+  LoadKeyVersions('\SOFTWARE\'+ LWOWNode + 'Embarcadero\BDS', BDSVersionPrefix);
+
 end;
 
 function TSynPasSyn.UseUserSettings(VersionIndex: Integer): Boolean;

--- a/Source/SynHighlighterPas.pas
+++ b/Source/SynHighlighterPas.pas
@@ -1378,9 +1378,10 @@ var
 begin
   { returns the user settings that exist in the registry }
   // See UseUserSettings below where these strings are used
-  LWowNode := '';
   {$ifdef WIN64}
-    LWowNode := 'WOW6432Node\';
+  LWowNode := 'WOW6432Node\';
+  {$else}
+  LWowNode := '';
   {$ENDIF}
 
   LoadKeyVersions('\SOFTWARE\'+ LWOWNode + 'Borland\Delphi', '');


### PR DESCRIPTION
Keys for the delphi IDE are stored in the 32 bit section of regedit. Use WOW6432Node for 64 bit to be able to find the 32 bit node
See https://support.microsoft.com/de-de/help/305097/how-to-view-the-system-registry-by-using-64-bit-versions-of-windows for more info.