### PR TITLE
Fixed 10.3 packages and removed unused variable

### DIFF
--- a/Packages/103R/SynEdit_D.dproj
+++ b/Packages/103R/SynEdit_D.dproj
@@ -50,6 +50,7 @@
         <VerInfo_Locale>1031</VerInfo_Locale>
         <DCC_E>false</DCC_E>
         <DCC_F>false</DCC_F>
+        <DllSuffix>103R</DllSuffix>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>SynEdit_R;$(DCC_UsePackage)</DCC_UsePackage>

--- a/Packages/103R/SynEdit_R.dpk
+++ b/Packages/103R/SynEdit_R.dpk
@@ -91,6 +91,7 @@ contains
   SynHighlighterFoxpro in '..\..\Source\SynHighlighterFoxpro.pas',
   SynHighlighterGalaxy in '..\..\Source\SynHighlighterGalaxy.pas',
   SynHighlighterGeneral in '..\..\Source\SynHighlighterGeneral.pas',
+  SynHighlighterGLSL in '..\..\Source\SynHighlighterGLSL.pas',
   SynHighlighterGWS in '..\..\Source\SynHighlighterGWS.pas',
   SynHighlighterHashEntries in '..\..\Source\SynHighlighterHashEntries.pas',
   SynHighlighterHaskell in '..\..\Source\SynHighlighterHaskell.pas',

--- a/Packages/103R/SynEdit_R.dproj
+++ b/Packages/103R/SynEdit_R.dproj
@@ -56,6 +56,7 @@
         <VerInfo_Locale>1031</VerInfo_Locale>
         <DCC_F>false</DCC_F>
         <DCC_E>false</DCC_E>
+        <DllSuffix>103R</DllSuffix>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
@@ -155,6 +156,7 @@
         <DCCReference Include="..\..\Source\SynHighlighterFoxpro.pas"/>
         <DCCReference Include="..\..\Source\SynHighlighterGalaxy.pas"/>
         <DCCReference Include="..\..\Source\SynHighlighterGeneral.pas"/>
+        <DCCReference Include="..\..\Source\SynHighlighterGLSL.pas"/>
         <DCCReference Include="..\..\Source\SynHighlighterGWS.pas"/>
         <DCCReference Include="..\..\Source\SynHighlighterHashEntries.pas"/>
         <DCCReference Include="..\..\Source\SynHighlighterHaskell.pas"/>

--- a/Source/SynEdit.pas
+++ b/Source/SynEdit.pas
@@ -4954,7 +4954,6 @@ var
   nMaxScroll: Integer;
   ScrollInfo: TScrollInfo;
   iRightChar: Integer;
-  iClientRect: TRect;
 begin
   if not HandleAllocated or (PaintLock <> 0) then
     Include(FStateFlags, sfScrollbarChanged)


### PR DESCRIPTION
The missing DllSuffix in the dproj caused some glitches that resulted in wrong bpl names.