### PR TITLE
Update: Type changed to TCustomIniFile for use both TMemIniFile and TIniFile

### DIFF
--- a/Source/SynEditHighlighter.pas
+++ b/Source/SynEditHighlighter.pas
@@ -80,8 +80,9 @@ type
       OldStyle: Boolean): Boolean; virtual;
     function LoadFromRegistry(Reg: TBetterRegistry): Boolean;
     function SaveToRegistry(Reg: TBetterRegistry): Boolean;
-    function LoadFromFile(Ini: TIniFile): Boolean;
-    function SaveToFile(Ini: TIniFile): Boolean;
+//Fix type changed to TCustomIniFile for use both TMemIniFile and TIniFile
+    function LoadFromFile(Ini: TCustomIniFile): Boolean;
+    function SaveToFile(Ini: TCustomIniFile): Boolean;
   public
     procedure SetColors(Foreground, Background: TColor);
     property FriendlyName: UnicodeString read FFriendlyName;
@@ -704,7 +705,7 @@ begin
     Result := False;
 end;
 
-function TSynHighlighterAttributes.LoadFromFile(Ini : TIniFile): Boolean;
+function TSynHighlighterAttributes.LoadFromFile(Ini : TCustomIniFile): boolean;
 var
   S: TStringList;
 begin
@@ -728,7 +729,7 @@ begin
   end;
 end;
 
-function TSynHighlighterAttributes.SaveToFile(Ini : TIniFile): Boolean;
+function TSynHighlighterAttributes.SaveToFile(Ini : TCustomIniFile): boolean;
 begin
   Ini.WriteInteger(Name, 'Background', Background);
   Ini.WriteInteger(Name, 'Foreground', Foreground);


### PR DESCRIPTION
After change  TSynHighlighterAttributes functions  LoadFromFile/SaveToFile  can use type TMemIniFile and load/save attributes not only from a file but also from TStringList  (file name may be empty)