### PR TITLE
UNDO does not work correctly when IME is used when there is range-selected text.

### DIFF
--- a/Source/SynEdit.pas
+++ b/Source/SynEdit.pas
@@ -8167,11 +8167,13 @@ begin
           begin
             BeginUndoBlock;
             try
-              FUndoList.AddChange(crDelete, FBlockBegin, FBlockEnd, Helper,
+              FUndoList.AddChange(crDelete, FBlockBegin, FBlockEnd, SelText,
                 smNormal);
-              StartOfBlock := FBlockBegin;
+              StartOfBlock := BlockBegin;
+              EndOfBlock.Line := BlockBegin.Line;
+              EndOfBlock.Char := BlockBegin.Char + Length(s);
               SetSelTextPrimitive(s);
-              FUndoList.AddChange(crInsert, FBlockBegin, FBlockEnd, Helper,
+              FUndoList.AddChange(crInsert, StartOfBlock, EndOfBlock, '',
                 smNormal);
             finally
               EndUndoBlock;


### PR DESCRIPTION
Fixed a bug that UNDO does not work properly when inputting from IME after selecting text.

In the `TCustomSynEdit.ExecuteCommand()` method, if there is a character string selection process during the `ecImeStr` process, the undo will not work because the arguments of the two `FUndoList.AddChange()` method calls are incorrect.