### PR TITLE
Improved ECMA Script highlighter

### DIFF
--- a/Source/SynHighlighterECMAScript.pas
+++ b/Source/SynHighlighterECMAScript.pas
@@ -870,7 +870,7 @@ end;
 function TSynECMAScriptSyn.IsIdentChar(AChar: WideChar): Boolean;
 begin
   case AChar of
-    'A'..'Z', 'a'..'z', '_', '$',
+    'A'..'Z', 'a'..'z', '_', '$', '0'..'9',
     #$00AA, #$00B5, #$00BA, #$00C0..#$00D6, #$00D8..#$00F6, #$00F8..#$02C1:
       Result := True;
     else

--- a/Source/SynHighlighterECMAScript.pas
+++ b/Source/SynHighlighterECMAScript.pas
@@ -45,6 +45,9 @@ uses
   SynEditTypes,
   SynEditHighlighter,
   SynUnicode,
+{$IFDEF SYN_CodeFolding}
+  SynEditCodeFolding,
+{$ENDIF}
   SysUtils,
   Classes;
 
@@ -62,8 +65,8 @@ type
     tkSymbol,
     tkUnknown);
 
-  TRangeState = (rsUnknown, rsMultiLineComment, rsSingleLineComment,
-    rsDoubleQuotedString, rsSingleQuotedString);
+  TRangeState = (rsUnknown, rsMultiLineComment, rsSingleLineComment { not used },
+    rsDoubleQuotedString, rsSingleQuotedString, rsBacktickQuotedString);
 
   TProcTableProc = procedure of object;
 
@@ -71,7 +74,11 @@ type
   TIdentFuncTableFunc = function (Index: Integer): TtkTokenKind of object;
 
 type
+{$IFDEF SYN_CodeFolding}
+  TSynECMAScriptSyn = class(TSynCustomCodeFoldingHighlighter)
+{$ELSE}
   TSynECMAScriptSyn = class(TSynCustomHighlighter)
+{$ENDIF}
   private
     FRange: TRangeState;
     FTokenId: TtkTokenKind;
@@ -134,6 +141,9 @@ type
     function GetTokenKind: Integer; override;
     function IsIdentChar(AChar: WideChar): Boolean; override;
     procedure Next; override;
+{$IFDEF SYN_CodeFolding}
+    procedure ScanForFoldRanges(FoldRanges: TSynFoldRanges; LinesToScan: TStrings; FromLine: Integer; ToLine: Integer); override;
+{$ENDIF}
   published
     property CommentAttri: TSynHighlighterAttributes read FCommentAttri write FCommentAttri;
     property IdentifierAttri: TSynHighlighterAttributes read FIdentifierAttri write FIdentifierAttri;
@@ -155,7 +165,6 @@ resourcestring
   SYNS_FriendlyLangECMAScript = 'ECMA Script';
 
 const
-  // as this language is case-insensitive keywords *must* be in lowercase
   KeyWords: array[0..52] of UnicodeString = (
     'as', 'async', 'await', 'break', 'case', 'catch', 'class', 'const',
     'continue', 'debugger', 'default', 'delete', 'do', 'else', 'enum', 'export',
@@ -178,7 +187,7 @@ const
 constructor TSynECMAScriptSyn.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
-  FCaseSensitive := False;
+  FCaseSensitive := True;
 
   FCommentAttri := TSynHighLighterAttributes.Create(SYNS_AttrComment, SYNS_FriendlyAttrComment);
   FCommentAttri.Style := [fsItalic];
@@ -218,6 +227,9 @@ begin
     if KeyIndices[i] = -1 then
       FIdentFuncTable[i] := AltFunc;
 
+{ we could get rid of all this (and some more elsewhere) if we stop
+  differentiating between keyword types, which we do in the end anyway,
+  when we apply the same attribute to tkKey, tkReserved and tkStrict }
   FIdentFuncTable[12] := FuncReservedWord;
   FIdentFuncTable[65] := FuncKeyWord;
   FIdentFuncTable[106] := FuncKeyWord;
@@ -521,15 +533,12 @@ begin
     '/':
       begin
         FTokenId := tkComment;
-        FRange := rsSingleLineComment;
         repeat
           Inc(Run);
         until IsLineEnd(Run);
-        FTokenId := tkComment;
       end;
     '*':
       begin
-        Inc(Run, 1);
         FRange := rsMultiLineComment;
         FTokenId := tkComment;
         repeat
@@ -547,6 +556,8 @@ begin
         Inc(Run);
         FTokenID := tkSymbol;
       end;
+  else
+    FTokenId := tkSymbol;
   end;
 end;
 
@@ -567,8 +578,7 @@ begin
           FRange := rsUnknown;
           Break;
         end;
-        if not IsLineEnd(Run) then
-          Inc(Run);
+        Inc(Run);
       until IsLineEnd(Run);
     end;
   end;
@@ -591,19 +601,53 @@ begin
 end;
 
 procedure TSynECMAScriptSyn.StringProc;
+
+  function IsEscaped: Boolean;
+  var
+    iFirstSlashPos: Integer;
+  begin
+    iFirstSlashPos := Run - 1;
+    while (iFirstSlashPos > 0) and (FLine[iFirstSlashPos] = '\') do
+      Dec(iFirstSlashPos);
+    Result := (Run - iFirstSlashPos + 1) mod 2 <> 0;
+  end;
+
+const
+  QuoteChars: array [rsDoubleQuotedString..rsBacktickQuotedString] of Char = ('"', #39, '`');
 var
-  QuoteChar: UnicodeString;
+  QuoteChar: Char;
 begin
   FTokenID := tkString;
-  QuoteChar := FLine[Run];   // We could have '"' or #39
-  if (FLine[Run + 1] = QuoteChar) and (FLine[Run + 2] = QuoteChar) then Inc(Run, 2);
-  repeat
-    if IsLineEnd(Run) then
-      Break;
+  if not (FRange in [rsDoubleQuotedString..rsBacktickQuotedString]) then
+  begin
+    case FLine[Run] of
+      '"': FRange := rsDoubleQuotedString;
+      #39: FRange := rsSingleQuotedString;
+      '`': FRange := rsBacktickQuotedString;
+    end;
     Inc(Run);
-  until (FLine[Run] = QuoteChar) and (FLine[Pred(Run)] <> '\');
-  if not IsLineEnd(Run) then
+  end
+  else if IsLineEnd(Run) then
+  begin
+    if (FRange <> rsBacktickQuotedString) and not IsEscaped then FRange := rsUnknown;
     Inc(Run);
+    Exit;
+  end;
+
+  QuoteChar := QuoteChars[FRange];
+  while not IsLineEnd(Run) do
+  begin
+    if (FLine[Run] = QuoteChar) then
+    begin
+      FRange := rsUnknown;
+      Inc(Run);
+      Exit;
+    end
+    else if (FLine[Run] = '\') and ((FLine[Run+1] = '\') or (FLine[Run+1] = QuoteChar)) then
+      Inc(Run);
+
+    Inc(Run);
+  end;
 end;
 
 procedure TSynECMAScriptSyn.IdentProc;
@@ -691,6 +735,7 @@ begin
   FTokenPos := Run;
   case FRange of
     rsMultiLineComment: MultiLineCommentProc;
+    rsDoubleQuotedString..rsBacktickQuotedString: StringProc;
   else
     case FLine[Run] of
       #0:
@@ -701,7 +746,7 @@ begin
         CRProc;
       #1..#9, #11, #12, #14..#32:
         SpaceProc;
-      '"', #39:
+      '"', #39, '`':
         StringProc;
       '%':
         ModSymbolProc;
@@ -739,8 +784,8 @@ begin
         SymbolProc;
       '0'..'9':
         NumberProc;
-      'A'..'Z', 'a'..'z', '_', '$', #$AA, #$B5, #$BA, #$C0..#$D6, #$D8..#$F6,
-      #$0F8..#$2C1:
+      'A'..'Z', 'a'..'z', '_', '$', 
+      #$00AA, #$00B5, #$00BA, #$00C0..#$00D6, #$00D8..#$00F6, #$00F8..#$02C1: { see documentation for HIGHCHARUNICODE }
         IdentProc;
     else
       UnknownProc;
@@ -825,8 +870,8 @@ end;
 function TSynECMAScriptSyn.IsIdentChar(AChar: WideChar): Boolean;
 begin
   case AChar of
-    'A'..'Z', 'a'..'z', '_', '$', #$AA, #$B5, #$BA, #$C0..#$D6, #$D8..#$F6,
-    #$0F8..#$2C1:
+    'A'..'Z', 'a'..'z', '_', '$',
+    #$00AA, #$00B5, #$00BA, #$00C0..#$00D6, #$00D8..#$00F6, #$00F8..#$02C1:
       Result := True;
     else
       Result := False;
@@ -882,6 +927,119 @@ function TSynECMAScriptSyn.GetRange: Pointer;
 begin
   Result := Pointer(FRange);
 end;
+
+{$IFDEF SYN_CodeFolding}
+procedure TSynECMAScriptSyn.ScanForFoldRanges(FoldRanges: TSynFoldRanges; LinesToScan: TStrings; FromLine, ToLine: Integer);
+var
+  CurLine: String;
+  Line: Integer;
+
+  function LineHasChar(Line: Integer; Character: Char; StartCol: Integer): Boolean; // faster than Pos!
+  var
+    i: Integer;
+  begin
+    Result := False;
+    for i := StartCol to Length(CurLine) do
+      if CurLine[i] = Character then
+        // Char must have proper highlighting (ignore stuff inside comments...)
+        if GetHighlighterAttriAtRowCol(LinesToScan, Line, i) <> FCommentAttri then
+        begin
+          Result := True;
+          Break;
+        end;
+  end;
+
+  function FindBraces(Line: Integer) : Boolean;
+  var
+    Col : Integer;
+  begin
+    Result := False;
+    for Col := 1 to Length(CurLine) do
+    begin
+      // We've found a starting character
+      if CurLine[Col] = '{' then
+      begin
+        // Char must have proper highlighting (ignore stuff inside comments...)
+        if GetHighlighterAttriAtRowCol(LinesToScan, Line, Col) <> FCommentAttri then
+        begin
+          // And ignore lines with both opening and closing chars in them
+          if not LineHasChar(Line, '}', Col + 1) then
+          begin
+            FoldRanges.StartFoldRange(Line + 1, 1);
+            Result := True;
+          end;
+          // Skip until a newline
+          Break;
+        end;
+      end
+      else if CurLine[col] = '}' then
+      begin
+        if GetHighlighterAttriAtRowCol(LinesToScan, Line, Col) <> FCommentAttri then
+        begin
+          // And ignore lines with both opening and closing chars in them
+          if not LineHasChar(Line, '{', Col + 1) then begin
+            FoldRanges.StopFoldRange(Line + 1, 1);
+            Result := True;
+          end;
+          // Skip until a newline
+          Break;
+        end;
+      end;
+    end; // for Col
+  end;
+
+  function FoldRegion(Line: Integer): Boolean;
+  var
+    S : string;
+  begin
+    Result := False;
+    S := TrimLeft(CurLine);
+    if Uppercase(Copy(S, 1, 9)) = '//#REGION' then
+    begin
+      FoldRanges.StartFoldRange(Line + 1, FoldRegionType);
+      Result := True;
+    end
+    else if Uppercase(Copy(S, 1, 12)) = '//#ENDREGION' then
+    begin
+      FoldRanges.StopFoldRange(Line + 1, FoldRegionType);
+      Result := True;
+    end;
+  end;
+
+begin
+  for Line := FromLine to ToLine do
+  begin
+    // Deal first with Multiline comments (Fold Type 2)
+    if TRangeState(GetLineRange(LinesToScan, Line)) = rsMultiLineComment then
+    begin
+      if TRangeState(GetLineRange(LinesToScan, Line - 1)) <> rsMultiLineComment then
+        FoldRanges.StartFoldRange(Line + 1, 2)
+      else
+        FoldRanges.NoFoldInfo(Line + 1);
+      Continue;
+    end
+    else if TRangeState(GetLineRange(LinesToScan, Line - 1)) = rsMultiLineComment then
+    begin
+      FoldRanges.StopFoldRange(Line + 1, 2);
+      Continue;
+    end;
+
+    CurLine := LinesToScan[Line];
+
+    // Skip empty lines
+    if CurLine = '' then begin
+      FoldRanges.NoFoldInfo(Line + 1);
+      Continue;
+    end;
+
+    // Find Fold regions
+    if FoldRegion(Line) then Continue;
+
+    // Find an braces on this line  (Fold Type 1)
+    if not FindBraces(Line) then FoldRanges.NoFoldInfo(Line + 1);
+  end;
+end;
+{$ENDIF}
 
 initialization
   RegisterPlaceableHighlighter(TSynECMAScriptSyn);


### PR DESCRIPTION
New
- code folding support
- backtick (multi-line) strings
- line continuation with backslash for ordinary strings

Fixed
- compiler errors caused by ambiguous hexadecimal literals
- glitch with disappearing '/*' when opening comment
